### PR TITLE
Add database schema samples with comprehensive enum type examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,128 @@
-# sample-schema
+# Database Schema Samples with Enum Types
+
+This repository contains sample database schemas demonstrating the use of Enum types across different database engines and ORM tools.
+
+## 📁 Directory Structure
+
+```
+sample-schema/
+├── postgres/       # PostgreSQL native enum types
+├── mysql/          # MySQL ENUM column types  
+├── prisma/         # Prisma ORM schema definitions
+├── tbls/           # tbls documentation tool schemas
+└── schemarb/       # Rails Active Record schemas
+```
+
+## 🎯 Purpose
+
+Each directory contains example schemas that demonstrate:
+- Various enum type definitions
+- Different use cases for enums (status, categories, priorities, etc.)
+- Best practices for each platform
+- Relationships between tables using enums
+- Array/SET types where supported
+
+## 📋 Enum Types Included
+
+All examples include the following enum types:
+- **User Status**: active, inactive, suspended, pending_verification, deleted
+- **Order Status**: pending, processing, shipped, delivered, cancelled, refunded
+- **Payment Methods**: credit_card, debit_card, paypal, bank_transfer, etc.
+- **Priority Levels**: low, medium, high, urgent, critical
+- **Ticket Severity**: trivial, minor, major, critical, blocker
+- **Product Categories**: electronics, clothing, books, food, etc.
+- **Notification Types**: email, sms, push, in_app, webhook
+
+## 🚀 Quick Start
+
+### PostgreSQL
+```bash
+cd postgres/
+psql -U your_user -d your_database -f schema.sql
+```
+
+### MySQL
+```bash
+cd mysql/
+mysql -u your_user -p your_database < schema.sql
+```
+
+### Prisma
+```bash
+cd prisma/
+npm install prisma @prisma/client
+npx prisma db push
+```
+
+### tbls
+```bash
+cd tbls/
+# First apply the PostgreSQL schema
+psql -U your_user -d your_database -f schema.sql
+# Then generate documentation
+tbls doc
+```
+
+### Rails (schemarb)
+```bash
+cd schemarb/
+# Copy schema.rb to your Rails db/ directory
+# Copy models_example.rb content to your app/models/
+rails db:schema:load
+```
+
+## 📝 Features by Platform
+
+### PostgreSQL
+- Native ENUM types
+- Array of enums support
+- Type comments for documentation
+- Functions and triggers using enums
+
+### MySQL  
+- ENUM column types
+- SET type for multiple values
+- Stored procedures with enum parameters
+- Triggers for enum validation
+
+### Prisma
+- Enum definitions in schema
+- Array enum fields
+- Relations with enum constraints
+- Multi-database support ready
+
+### tbls
+- Comprehensive table/column comments
+- Configuration for documentation
+- Lint rules for schema quality
+- ER diagram generation support
+
+### Rails
+- Integer-based enums (Rails convention)
+- PostgreSQL native enum support
+- Model-level enum definitions
+- Scopes and helpers for enums
+
+## 🧪 Testing
+
+Each directory includes test data inserts to verify the schema works correctly. Run the schema files to create tables and insert sample data.
+
+## 📚 Documentation
+
+- [PostgreSQL Enum Types](https://www.postgresql.org/docs/current/datatype-enum.html)
+- [MySQL ENUM Type](https://dev.mysql.com/doc/refman/8.0/en/enum.html)
+- [Prisma Enums](https://www.prisma.io/docs/concepts/components/prisma-schema/data-model#enums)
+- [Rails Enums](https://api.rubyonrails.org/classes/ActiveRecord/Enum.html)
+- [tbls Documentation](https://github.com/k1LoW/tbls)
+
+## 🤝 Contributing
+
+Feel free to add more examples or improve existing schemas. Each schema should:
+1. Include comprehensive enum usage
+2. Follow platform best practices
+3. Include sample data
+4. Be well-commented
+
+## 📄 License
+
+MIT

--- a/mysql/schema.sql
+++ b/mysql/schema.sql
@@ -1,0 +1,229 @@
+-- MySQL Schema with Enum Types Sample
+
+-- Create database (uncomment if needed)
+-- CREATE DATABASE IF NOT EXISTS sample_schema;
+-- USE sample_schema;
+
+-- Drop existing tables if they exist
+DROP TABLE IF EXISTS order_items;
+DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS support_tickets;
+DROP TABLE IF EXISTS notification_preferences;
+DROP TABLE IF EXISTS users;
+
+-- Create Tables with inline ENUM types (MySQL style)
+
+-- Users table with status enum
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    username VARCHAR(100) UNIQUE NOT NULL,
+    status ENUM('active', 'inactive', 'suspended', 'pending_verification', 'deleted') 
+        DEFAULT 'pending_verification' NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Products table with category enum
+CREATE TABLE products (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    price DECIMAL(10, 2) NOT NULL,
+    category ENUM('electronics', 'clothing', 'books', 'food', 'home_garden', 'sports', 'toys', 'health_beauty') NOT NULL,
+    stock_quantity INT DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_category (category)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Orders table with status and payment method enums
+CREATE TABLE orders (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT,
+    status ENUM('pending', 'processing', 'shipped', 'delivered', 'cancelled', 'refunded') 
+        DEFAULT 'pending' NOT NULL,
+    payment_method ENUM('credit_card', 'debit_card', 'paypal', 'bank_transfer', 'cash_on_delivery', 'cryptocurrency') NOT NULL,
+    total_amount DECIMAL(10, 2) NOT NULL,
+    shipping_address TEXT,
+    order_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_status (status),
+    INDEX idx_user_id (user_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Order items table
+CREATE TABLE order_items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    order_id INT,
+    product_id INT,
+    quantity INT NOT NULL,
+    unit_price DECIMAL(10, 2) NOT NULL,
+    subtotal DECIMAL(10, 2) NOT NULL,
+    FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE,
+    FOREIGN KEY (product_id) REFERENCES products(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Support tickets with priority and severity enums
+CREATE TABLE support_tickets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    priority ENUM('low', 'medium', 'high', 'urgent', 'critical') 
+        DEFAULT 'medium' NOT NULL,
+    severity ENUM('trivial', 'minor', 'major', 'critical', 'blocker') 
+        DEFAULT 'minor' NOT NULL,
+    assigned_to INT,
+    resolved_at TIMESTAMP NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_priority (priority),
+    INDEX idx_severity (severity),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Notification preferences with SET type (MySQL's alternative to array of enums)
+-- Using SET for multiple enum values and separate columns for weekdays
+CREATE TABLE notification_preferences (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT,
+    -- SET allows multiple values from the list
+    enabled_types SET('email', 'sms', 'push', 'in_app', 'webhook') 
+        DEFAULT 'email,in_app',
+    quiet_hours_start TIME,
+    quiet_hours_end TIME,
+    -- Using SET for quiet_days as well
+    quiet_days SET('monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday') 
+        DEFAULT '',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Create a view that uses enum types
+CREATE OR REPLACE VIEW active_user_orders AS
+SELECT 
+    u.id as user_id,
+    u.username,
+    u.email,
+    o.id as order_id,
+    o.status as order_status,
+    o.payment_method,
+    o.total_amount,
+    o.order_date
+FROM users u
+JOIN orders o ON u.id = o.user_id
+WHERE u.status = 'active';
+
+-- Create stored procedure that uses enum types
+DELIMITER //
+
+CREATE PROCEDURE GetOrdersByStatus(
+    IN p_status ENUM('pending', 'processing', 'shipped', 'delivered', 'cancelled', 'refunded')
+)
+BEGIN
+    SELECT 
+        id as order_id,
+        user_id,
+        status,
+        payment_method,
+        total_amount,
+        order_date
+    FROM orders
+    WHERE status = p_status;
+END //
+
+-- Create function to calculate order statistics by status
+CREATE FUNCTION GetOrderCountByStatus(
+    p_status ENUM('pending', 'processing', 'shipped', 'delivered', 'cancelled', 'refunded')
+) RETURNS INT
+DETERMINISTIC
+READS SQL DATA
+BEGIN
+    DECLARE order_count INT;
+    SELECT COUNT(*) INTO order_count
+    FROM orders
+    WHERE status = p_status;
+    RETURN order_count;
+END //
+
+-- Create trigger to validate enum transitions
+CREATE TRIGGER before_order_status_update
+BEFORE UPDATE ON orders
+FOR EACH ROW
+BEGIN
+    -- Example validation: cancelled orders cannot be changed to delivered
+    IF OLD.status = 'cancelled' AND NEW.status = 'delivered' THEN
+        SIGNAL SQLSTATE '45000' 
+        SET MESSAGE_TEXT = 'Cannot change cancelled order to delivered';
+    END IF;
+    
+    -- Example validation: delivered orders can only be refunded
+    IF OLD.status = 'delivered' AND NEW.status NOT IN ('delivered', 'refunded') THEN
+        SIGNAL SQLSTATE '45000' 
+        SET MESSAGE_TEXT = 'Delivered orders can only be refunded';
+    END IF;
+END //
+
+DELIMITER ;
+
+-- Insert sample data
+INSERT INTO users (email, username, status) VALUES
+    ('john.doe@example.com', 'johndoe', 'active'),
+    ('jane.smith@example.com', 'janesmith', 'active'),
+    ('bob.wilson@example.com', 'bobwilson', 'pending_verification'),
+    ('alice.brown@example.com', 'alicebrown', 'suspended');
+
+INSERT INTO products (name, description, price, category, stock_quantity) VALUES
+    ('Laptop Pro 15', 'High-performance laptop', 1299.99, 'electronics', 10),
+    ('Running Shoes', 'Professional running shoes', 89.99, 'sports', 25),
+    ('Organic Shampoo', 'Natural hair care product', 12.99, 'health_beauty', 50),
+    ('Programming Book', 'Learn MySQL', 45.99, 'books', 15);
+
+INSERT INTO orders (user_id, status, payment_method, total_amount, shipping_address) VALUES
+    (1, 'delivered', 'credit_card', 1299.99, '123 Main St, City, Country'),
+    (2, 'processing', 'paypal', 89.99, '456 Oak Ave, Town, Country'),
+    (1, 'pending', 'bank_transfer', 58.98, '123 Main St, City, Country');
+
+INSERT INTO order_items (order_id, product_id, quantity, unit_price, subtotal) VALUES
+    (1, 1, 1, 1299.99, 1299.99),
+    (2, 2, 1, 89.99, 89.99),
+    (3, 3, 2, 12.99, 25.98),
+    (3, 4, 1, 45.99, 45.99);
+
+INSERT INTO support_tickets (user_id, title, description, priority, severity) VALUES
+    (1, 'Cannot login', 'Getting error when trying to login', 'high', 'major'),
+    (2, 'Shipping delay', 'Order has not arrived yet', 'medium', 'minor'),
+    (3, 'Feature request', 'Add dark mode to website', 'low', 'trivial');
+
+-- Using SET type for multiple values
+INSERT INTO notification_preferences (user_id, enabled_types, quiet_hours_start, quiet_hours_end, quiet_days) VALUES
+    (1, 'email,push,in_app', '22:00', '08:00', 'saturday,sunday'),
+    (2, 'email', '23:00', '07:00', ''),
+    (3, 'email,sms,push', NULL, NULL, NULL);
+
+-- Example queries demonstrating ENUM usage
+
+-- Query using ENUM value
+SELECT * FROM users WHERE status = 'active';
+
+-- Query using SET type with FIND_IN_SET
+SELECT * FROM notification_preferences 
+WHERE FIND_IN_SET('push', enabled_types) > 0;
+
+-- Query to get all possible enum values for a column
+SELECT 
+    COLUMN_TYPE 
+FROM 
+    INFORMATION_SCHEMA.COLUMNS 
+WHERE 
+    TABLE_SCHEMA = DATABASE() 
+    AND TABLE_NAME = 'users' 
+    AND COLUMN_NAME = 'status';
+
+-- Query to check if specific day is in quiet_days SET
+SELECT * FROM notification_preferences 
+WHERE FIND_IN_SET('saturday', quiet_days) > 0;

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -1,0 +1,258 @@
+-- PostgreSQL Schema with Enum Types Sample
+
+-- Drop existing types if they exist (for idempotent execution)
+DROP TYPE IF EXISTS user_status CASCADE;
+DROP TYPE IF EXISTS order_status CASCADE;
+DROP TYPE IF EXISTS payment_method CASCADE;
+DROP TYPE IF EXISTS priority_level CASCADE;
+DROP TYPE IF EXISTS notification_type CASCADE;
+DROP TYPE IF EXISTS weekday CASCADE;
+DROP TYPE IF EXISTS ticket_severity CASCADE;
+DROP TYPE IF EXISTS product_category CASCADE;
+
+-- Create Enum Types
+CREATE TYPE user_status AS ENUM (
+    'active',
+    'inactive',
+    'suspended',
+    'pending_verification',
+    'deleted'
+);
+
+CREATE TYPE order_status AS ENUM (
+    'pending',
+    'processing',
+    'shipped',
+    'delivered',
+    'cancelled',
+    'refunded'
+);
+
+CREATE TYPE payment_method AS ENUM (
+    'credit_card',
+    'debit_card',
+    'paypal',
+    'bank_transfer',
+    'cash_on_delivery',
+    'cryptocurrency'
+);
+
+CREATE TYPE priority_level AS ENUM (
+    'low',
+    'medium',
+    'high',
+    'urgent',
+    'critical'
+);
+
+CREATE TYPE notification_type AS ENUM (
+    'email',
+    'sms',
+    'push',
+    'in_app',
+    'webhook'
+);
+
+CREATE TYPE weekday AS ENUM (
+    'monday',
+    'tuesday',
+    'wednesday',
+    'thursday',
+    'friday',
+    'saturday',
+    'sunday'
+);
+
+CREATE TYPE ticket_severity AS ENUM (
+    'trivial',
+    'minor',
+    'major',
+    'critical',
+    'blocker'
+);
+
+CREATE TYPE product_category AS ENUM (
+    'electronics',
+    'clothing',
+    'books',
+    'food',
+    'home_garden',
+    'sports',
+    'toys',
+    'health_beauty'
+);
+
+-- Drop existing tables if they exist
+DROP TABLE IF EXISTS order_items CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+DROP TABLE IF EXISTS products CASCADE;
+DROP TABLE IF EXISTS support_tickets CASCADE;
+DROP TABLE IF EXISTS notification_preferences CASCADE;
+DROP TABLE IF EXISTS users CASCADE;
+
+-- Create Tables using Enum Types
+
+-- Users table with status enum
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    username VARCHAR(100) UNIQUE NOT NULL,
+    status user_status DEFAULT 'pending_verification' NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Products table with category enum
+CREATE TABLE products (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    price DECIMAL(10, 2) NOT NULL,
+    category product_category NOT NULL,
+    stock_quantity INTEGER DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Orders table with status and payment method enums
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    status order_status DEFAULT 'pending' NOT NULL,
+    payment_method payment_method NOT NULL,
+    total_amount DECIMAL(10, 2) NOT NULL,
+    shipping_address TEXT,
+    order_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Order items table
+CREATE TABLE order_items (
+    id SERIAL PRIMARY KEY,
+    order_id INTEGER REFERENCES orders(id) ON DELETE CASCADE,
+    product_id INTEGER REFERENCES products(id),
+    quantity INTEGER NOT NULL,
+    unit_price DECIMAL(10, 2) NOT NULL,
+    subtotal DECIMAL(10, 2) NOT NULL
+);
+
+-- Support tickets with priority and severity enums
+CREATE TABLE support_tickets (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    priority priority_level DEFAULT 'medium' NOT NULL,
+    severity ticket_severity DEFAULT 'minor' NOT NULL,
+    assigned_to INTEGER,
+    resolved_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Notification preferences with array of enum types
+CREATE TABLE notification_preferences (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    enabled_types notification_type[] DEFAULT '{email, in_app}',
+    quiet_hours_start TIME,
+    quiet_hours_end TIME,
+    quiet_days weekday[] DEFAULT '{}',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create indexes for better performance
+CREATE INDEX idx_users_status ON users(status);
+CREATE INDEX idx_orders_status ON orders(status);
+CREATE INDEX idx_orders_user_id ON orders(user_id);
+CREATE INDEX idx_tickets_priority ON support_tickets(priority);
+CREATE INDEX idx_tickets_severity ON support_tickets(severity);
+CREATE INDEX idx_products_category ON products(category);
+
+-- Create a view that uses enum types
+CREATE OR REPLACE VIEW active_user_orders AS
+SELECT 
+    u.id as user_id,
+    u.username,
+    u.email,
+    o.id as order_id,
+    o.status as order_status,
+    o.payment_method,
+    o.total_amount,
+    o.order_date
+FROM users u
+JOIN orders o ON u.id = o.user_id
+WHERE u.status = 'active';
+
+-- Sample function that uses enum types
+CREATE OR REPLACE FUNCTION get_orders_by_status(
+    p_status order_status
+) RETURNS TABLE (
+    order_id INTEGER,
+    user_id INTEGER,
+    total_amount DECIMAL,
+    order_date TIMESTAMP
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT id, user_id, total_amount, order_date
+    FROM orders
+    WHERE status = p_status;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger function to auto-update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create triggers for updated_at columns
+CREATE TRIGGER update_users_updated_at BEFORE UPDATE ON users
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_orders_updated_at BEFORE UPDATE ON orders
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_tickets_updated_at BEFORE UPDATE ON support_tickets
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_notification_preferences_updated_at BEFORE UPDATE ON notification_preferences
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Insert sample data
+INSERT INTO users (email, username, status) VALUES
+    ('john.doe@example.com', 'johndoe', 'active'),
+    ('jane.smith@example.com', 'janesmith', 'active'),
+    ('bob.wilson@example.com', 'bobwilson', 'pending_verification'),
+    ('alice.brown@example.com', 'alicebrown', 'suspended');
+
+INSERT INTO products (name, description, price, category, stock_quantity) VALUES
+    ('Laptop Pro 15', 'High-performance laptop', 1299.99, 'electronics', 10),
+    ('Running Shoes', 'Professional running shoes', 89.99, 'sports', 25),
+    ('Organic Shampoo', 'Natural hair care product', 12.99, 'health_beauty', 50),
+    ('Programming Book', 'Learn PostgreSQL', 45.99, 'books', 15);
+
+INSERT INTO orders (user_id, status, payment_method, total_amount, shipping_address) VALUES
+    (1, 'delivered', 'credit_card', 1299.99, '123 Main St, City, Country'),
+    (2, 'processing', 'paypal', 89.99, '456 Oak Ave, Town, Country'),
+    (1, 'pending', 'bank_transfer', 58.98, '123 Main St, City, Country');
+
+INSERT INTO order_items (order_id, product_id, quantity, unit_price, subtotal) VALUES
+    (1, 1, 1, 1299.99, 1299.99),
+    (2, 2, 1, 89.99, 89.99),
+    (3, 3, 2, 12.99, 25.98),
+    (3, 4, 1, 45.99, 45.99);
+
+INSERT INTO support_tickets (user_id, title, description, priority, severity) VALUES
+    (1, 'Cannot login', 'Getting error when trying to login', 'high', 'major'),
+    (2, 'Shipping delay', 'Order has not arrived yet', 'medium', 'minor'),
+    (3, 'Feature request', 'Add dark mode to website', 'low', 'trivial');
+
+INSERT INTO notification_preferences (user_id, enabled_types, quiet_hours_start, quiet_hours_end, quiet_days) VALUES
+    (1, '{email, push, in_app}', '22:00', '08:00', '{saturday, sunday}'),
+    (2, '{email}', '23:00', '07:00', '{}'),
+    (3, '{email, sms, push}', NULL, NULL, NULL);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,276 @@
+// Prisma Schema with Enum Types Sample
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql" // Can be changed to mysql, sqlite, sqlserver, mongodb, cockroachdb
+  url      = env("DATABASE_URL")
+}
+
+// Define Enums
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  SUSPENDED
+  PENDING_VERIFICATION
+  DELETED
+}
+
+enum OrderStatus {
+  PENDING
+  PROCESSING
+  SHIPPED
+  DELIVERED
+  CANCELLED
+  REFUNDED
+}
+
+enum PaymentMethod {
+  CREDIT_CARD
+  DEBIT_CARD
+  PAYPAL
+  BANK_TRANSFER
+  CASH_ON_DELIVERY
+  CRYPTOCURRENCY
+}
+
+enum PriorityLevel {
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
+  CRITICAL
+}
+
+enum NotificationType {
+  EMAIL
+  SMS
+  PUSH
+  IN_APP
+  WEBHOOK
+}
+
+enum Weekday {
+  MONDAY
+  TUESDAY
+  WEDNESDAY
+  THURSDAY
+  FRIDAY
+  SATURDAY
+  SUNDAY
+}
+
+enum TicketSeverity {
+  TRIVIAL
+  MINOR
+  MAJOR
+  CRITICAL
+  BLOCKER
+}
+
+enum ProductCategory {
+  ELECTRONICS
+  CLOTHING
+  BOOKS
+  FOOD
+  HOME_GARDEN
+  SPORTS
+  TOYS
+  HEALTH_BEAUTY
+}
+
+// Role enum for user permissions
+enum Role {
+  USER
+  MODERATOR
+  ADMIN
+  SUPER_ADMIN
+}
+
+// Define Models
+
+model User {
+  id                       Int                       @id @default(autoincrement())
+  email                    String                    @unique
+  username                 String                    @unique
+  password                 String?
+  status                   UserStatus                @default(PENDING_VERIFICATION)
+  role                     Role                      @default(USER)
+  profile                  Profile?
+  orders                   Order[]
+  supportTickets           SupportTicket[]
+  notificationPreferences  NotificationPreference?
+  createdAt                DateTime                  @default(now())
+  updatedAt                DateTime                  @updatedAt
+  
+  @@index([status])
+  @@index([role])
+}
+
+model Profile {
+  id          Int      @id @default(autoincrement())
+  userId      Int      @unique
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  firstName   String?
+  lastName    String?
+  bio         String?
+  avatarUrl   String?
+  phoneNumber String?
+  birthDate   DateTime?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model Product {
+  id            Int             @id @default(autoincrement())
+  name          String
+  description   String?
+  price         Decimal         @db.Decimal(10, 2)
+  category      ProductCategory
+  stockQuantity Int             @default(0)
+  sku           String          @unique
+  isActive      Boolean         @default(true)
+  orderItems    OrderItem[]
+  reviews       Review[]
+  createdAt     DateTime        @default(now())
+  updatedAt     DateTime        @updatedAt
+  
+  @@index([category])
+  @@index([isActive])
+}
+
+model Order {
+  id              Int           @id @default(autoincrement())
+  userId          Int
+  user            User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  status          OrderStatus   @default(PENDING)
+  paymentMethod   PaymentMethod
+  totalAmount     Decimal       @db.Decimal(10, 2)
+  shippingAddress String?       @db.Text
+  orderNumber     String        @unique @default(uuid())
+  orderItems      OrderItem[]
+  payment         Payment?
+  shipment        Shipment?
+  orderDate       DateTime      @default(now())
+  updatedAt       DateTime      @updatedAt
+  
+  @@index([status])
+  @@index([userId])
+}
+
+model OrderItem {
+  id         Int     @id @default(autoincrement())
+  orderId    Int
+  order      Order   @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  productId  Int
+  product    Product @relation(fields: [productId], references: [id])
+  quantity   Int
+  unitPrice  Decimal @db.Decimal(10, 2)
+  subtotal   Decimal @db.Decimal(10, 2)
+  
+  @@unique([orderId, productId])
+}
+
+model Payment {
+  id              Int           @id @default(autoincrement())
+  orderId         Int           @unique
+  order           Order         @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  amount          Decimal       @db.Decimal(10, 2)
+  paymentMethod   PaymentMethod
+  transactionId   String?       @unique
+  status          String        // Could be another enum: PENDING, COMPLETED, FAILED, REFUNDED
+  processedAt     DateTime?
+  createdAt       DateTime      @default(now())
+}
+
+model Shipment {
+  id              Int      @id @default(autoincrement())
+  orderId         Int      @unique
+  order           Order    @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  trackingNumber  String?  @unique
+  carrier         String?
+  shippedDate     DateTime?
+  deliveredDate   DateTime?
+  estimatedDelivery DateTime?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+}
+
+model SupportTicket {
+  id          Int            @id @default(autoincrement())
+  userId      Int
+  user        User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  title       String
+  description String         @db.Text
+  priority    PriorityLevel  @default(MEDIUM)
+  severity    TicketSeverity @default(MINOR)
+  assignedTo  Int?
+  resolvedAt  DateTime?
+  ticketNumber String        @unique @default(uuid())
+  comments    Comment[]
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+  
+  @@index([priority])
+  @@index([severity])
+}
+
+model Comment {
+  id        Int           @id @default(autoincrement())
+  ticketId  Int
+  ticket    SupportTicket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  content   String        @db.Text
+  authorId  Int
+  isInternal Boolean      @default(false)
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+}
+
+model NotificationPreference {
+  id              Int                @id @default(autoincrement())
+  userId          Int                @unique
+  user            User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  enabledTypes    NotificationType[] // Array of enum values
+  quietHoursStart DateTime?          @db.Time()
+  quietHoursEnd   DateTime?          @db.Time()
+  quietDays       Weekday[]          // Array of enum values
+  emailFrequency  String?            // Could be another enum: INSTANT, DAILY, WEEKLY
+  createdAt       DateTime           @default(now())
+  updatedAt       DateTime           @updatedAt
+}
+
+model Review {
+  id        Int      @id @default(autoincrement())
+  productId Int
+  product   Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
+  userId    Int
+  rating    Int      // 1-5 stars
+  title     String?
+  comment   String?  @db.Text
+  isVerified Boolean @default(false)
+  helpful   Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  
+  @@index([productId])
+  @@index([rating])
+  @@unique([productId, userId])
+}
+
+// Example of a model with composite enum usage
+model AuditLog {
+  id          Int      @id @default(autoincrement())
+  entityType  String   // e.g., "User", "Order", "Product"
+  entityId    Int
+  action      String   // e.g., "CREATE", "UPDATE", "DELETE"
+  userId      Int?
+  changes     Json?    // Store the changes as JSON
+  ipAddress   String?
+  userAgent   String?
+  createdAt   DateTime @default(now())
+  
+  @@index([entityType, entityId])
+  @@index([userId])
+}

--- a/schemarb/models_example.rb
+++ b/schemarb/models_example.rb
@@ -1,0 +1,344 @@
+# Rails Model Examples with Enum Definitions
+# These would typically be in app/models/ directory
+
+# app/models/user.rb
+class User < ApplicationRecord
+  has_one :profile, dependent: :destroy
+  has_many :orders, dependent: :destroy
+  has_many :support_tickets, dependent: :destroy
+  has_one :notification_preference, dependent: :destroy
+  has_many :reviews, dependent: :destroy
+  has_many :comments, dependent: :destroy
+  has_many :audit_logs, dependent: :nullify
+  
+  # Define enum with integer mapping (Rails convention)
+  enum status: {
+    active: 0,
+    inactive: 1,
+    suspended: 2,
+    pending_verification: 3,
+    deleted: 4
+  }
+  
+  enum role: {
+    user: 0,
+    moderator: 1,
+    admin: 2,
+    super_admin: 3
+  }
+  
+  # Or using string keys (Rails 7+)
+  # enum status: {
+  #   active: "active",
+  #   inactive: "inactive",
+  #   suspended: "suspended",
+  #   pending_verification: "pending_verification",
+  #   deleted: "deleted"
+  # }, _prefix: true
+  
+  # Validations
+  validates :email, presence: true, uniqueness: true
+  validates :username, presence: true, uniqueness: true
+  
+  # Scopes
+  scope :verified, -> { where(status: :active) }
+  scope :pending, -> { where(status: :pending_verification) }
+  scope :admins, -> { where(role: [:admin, :super_admin]) }
+end
+
+# app/models/order.rb
+class Order < ApplicationRecord
+  belongs_to :user
+  has_many :order_items, dependent: :destroy
+  has_many :products, through: :order_items
+  has_one :payment, dependent: :destroy
+  
+  # Define enums
+  enum status: {
+    pending: 0,
+    processing: 1,
+    shipped: 2,
+    delivered: 3,
+    cancelled: 4,
+    refunded: 5
+  }
+  
+  enum payment_method: {
+    credit_card: 0,
+    debit_card: 1,
+    paypal: 2,
+    bank_transfer: 3,
+    cash_on_delivery: 4,
+    cryptocurrency: 5
+  }
+  
+  # Using _prefix or _suffix to avoid method name conflicts
+  # enum status: { pending: 0, processing: 1 }, _prefix: :order
+  # This creates methods like: order_pending?, order_processing?
+  
+  # Validations
+  validates :order_number, presence: true, uniqueness: true
+  validates :total_amount, presence: true, numericality: { greater_than: 0 }
+  
+  # Callbacks
+  before_create :generate_order_number
+  
+  # Scopes
+  scope :recent, -> { order(created_at: :desc) }
+  scope :completed, -> { where(status: [:delivered, :refunded]) }
+  scope :in_progress, -> { where(status: [:pending, :processing, :shipped]) }
+  
+  private
+  
+  def generate_order_number
+    self.order_number ||= "ORD-#{SecureRandom.hex(8).upcase}"
+  end
+end
+
+# app/models/product.rb
+class Product < ApplicationRecord
+  has_many :order_items
+  has_many :orders, through: :order_items
+  has_many :reviews, dependent: :destroy
+  
+  # Define enum for category
+  enum category: {
+    electronics: 0,
+    clothing: 1,
+    books: 2,
+    food: 3,
+    home_garden: 4,
+    sports: 5,
+    toys: 6,
+    health_beauty: 7
+  }
+  
+  # Validations
+  validates :name, presence: true
+  validates :price, presence: true, numericality: { greater_than: 0 }
+  validates :sku, presence: true, uniqueness: true
+  
+  # Scopes
+  scope :available, -> { where(active: true).where("stock_quantity > ?", 0) }
+  scope :by_category, ->(category) { where(category: category) }
+  
+  # Instance methods
+  def in_stock?
+    stock_quantity > 0
+  end
+end
+
+# app/models/support_ticket.rb
+class SupportTicket < ApplicationRecord
+  belongs_to :user
+  belongs_to :assigned_to, class_name: 'User', optional: true
+  has_many :comments, as: :commentable, dependent: :destroy
+  
+  # Define enums
+  enum priority: {
+    low: 0,
+    medium: 1,
+    high: 2,
+    urgent: 3,
+    critical: 4
+  }, _prefix: true
+  
+  enum severity: {
+    trivial: 0,
+    minor: 1,
+    major: 2,
+    critical: 3,
+    blocker: 4
+  }, _prefix: true
+  
+  enum status: {
+    open: 0,
+    in_progress: 1,
+    waiting_on_customer: 2,
+    resolved: 3,
+    closed: 4
+  }
+  
+  # Validations
+  validates :title, presence: true
+  validates :description, presence: true
+  validates :ticket_number, presence: true, uniqueness: true
+  
+  # Callbacks
+  before_create :generate_ticket_number
+  
+  # Scopes
+  scope :unassigned, -> { where(assigned_to_id: nil) }
+  scope :assigned_to, ->(user) { where(assigned_to: user) }
+  scope :high_priority, -> { where(priority: [:high, :urgent, :critical]) }
+  scope :unresolved, -> { where.not(status: [:resolved, :closed]) }
+  
+  private
+  
+  def generate_ticket_number
+    self.ticket_number ||= "TICKET-#{SecureRandom.hex(6).upcase}"
+  end
+end
+
+# app/models/notification_preference.rb
+class NotificationPreference < ApplicationRecord
+  belongs_to :user
+  
+  # Define enum for notification types (stored as array of integers)
+  enum enabled_type: {
+    email: 0,
+    sms: 1,
+    push: 2,
+    in_app: 3,
+    webhook: 4
+  }, _prefix: true
+  
+  enum email_frequency: {
+    instant: 0,
+    daily: 1,
+    weekly: 2,
+    monthly: 3
+  }
+  
+  # For array columns, we can use scopes
+  scope :with_notification_type, ->(type) { 
+    where("? = ANY(enabled_types)", enabled_types[type]) 
+  }
+  
+  # Helper methods for array enum handling
+  def has_notification_type?(type)
+    enabled_types.include?(self.class.enabled_types[type])
+  end
+  
+  def add_notification_type(type)
+    type_value = self.class.enabled_types[type]
+    self.enabled_types << type_value unless enabled_types.include?(type_value)
+  end
+  
+  def remove_notification_type(type)
+    self.enabled_types.delete(self.class.enabled_types[type])
+  end
+end
+
+# app/models/payment.rb
+class Payment < ApplicationRecord
+  belongs_to :order
+  
+  # Reuse payment_method enum from Order or define separately
+  enum payment_method: {
+    credit_card: 0,
+    debit_card: 1,
+    paypal: 2,
+    bank_transfer: 3,
+    cash_on_delivery: 4,
+    cryptocurrency: 5
+  }
+  
+  enum status: {
+    pending: 0,
+    processing: 1,
+    completed: 2,
+    failed: 3,
+    refunded: 4,
+    partially_refunded: 5
+  }, _prefix: :payment
+  
+  # Validations
+  validates :amount, presence: true, numericality: { greater_than: 0 }
+  validates :transaction_id, uniqueness: true, allow_nil: true
+  
+  # Scopes
+  scope :successful, -> { where(status: :completed) }
+  scope :failed, -> { where(status: :failed) }
+end
+
+# app/models/review.rb
+class Review < ApplicationRecord
+  belongs_to :product
+  belongs_to :user
+  
+  # Rating could be an enum or just validated integer
+  # If using enum:
+  # enum rating: {
+  #   one_star: 1,
+  #   two_stars: 2,
+  #   three_stars: 3,
+  #   four_stars: 4,
+  #   five_stars: 5
+  # }, _prefix: true
+  
+  # Validations
+  validates :rating, presence: true, inclusion: { in: 1..5 }
+  validates :user_id, uniqueness: { scope: :product_id, 
+    message: "can only review a product once" }
+  
+  # Scopes
+  scope :verified, -> { where(verified_purchase: true) }
+  scope :with_comments, -> { where.not(comment: [nil, ""]) }
+  scope :highly_rated, -> { where(rating: [4, 5]) }
+end
+
+# app/models/audit_log.rb
+class AuditLog < ApplicationRecord
+  belongs_to :auditable, polymorphic: true
+  belongs_to :user, optional: true
+  
+  # Action could be an enum
+  enum action: {
+    create: 0,
+    update: 1,
+    delete: 2,
+    login: 3,
+    logout: 4,
+    password_change: 5
+  }, _prefix: true
+  
+  # Scopes
+  scope :recent, -> { order(created_at: :desc) }
+  scope :by_user, ->(user) { where(user: user) }
+  scope :for_model, ->(model_name) { where(auditable_type: model_name) }
+end
+
+# Example of using concerns for shared enum behavior
+# app/models/concerns/statusable.rb
+module Statusable
+  extend ActiveSupport::Concern
+  
+  included do
+    enum status: {
+      draft: 0,
+      pending: 1,
+      approved: 2,
+      rejected: 3,
+      archived: 4
+    }, _prefix: true
+    
+    scope :published, -> { where(status: :approved) }
+    scope :pending_review, -> { where(status: :pending) }
+  end
+  
+  def publish!
+    update!(status: :approved)
+  end
+  
+  def archive!
+    update!(status: :archived)
+  end
+end
+
+# Usage examples in Rails console:
+# user = User.create(email: "test@example.com", username: "testuser")
+# user.active!  # Set status to active
+# user.active?  # Check if status is active
+# User.active   # Scope to get all active users
+# 
+# order = Order.new
+# order.payment_method = :credit_card  # Set using symbol
+# order.payment_method = "credit_card" # Or string
+# order.payment_method = 0             # Or integer value
+# order.credit_card?                   # Check payment method
+# 
+# ticket = SupportTicket.new
+# ticket.priority_high!                # Set priority (with prefix)
+# ticket.priority_high?                # Check priority
+# SupportTicket.priority_high          # Scope for high priority tickets

--- a/schemarb/schema.rb
+++ b/schemarb/schema.rb
@@ -1,0 +1,271 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2024_08_06_120000) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  # When using PostgreSQL, you can use native enum types
+  # Create enum types (PostgreSQL specific)
+  create_enum :user_status, ["active", "inactive", "suspended", "pending_verification", "deleted"]
+  create_enum :order_status, ["pending", "processing", "shipped", "delivered", "cancelled", "refunded"]
+  create_enum :payment_method, ["credit_card", "debit_card", "paypal", "bank_transfer", "cash_on_delivery", "cryptocurrency"]
+  create_enum :priority_level, ["low", "medium", "high", "urgent", "critical"]
+  create_enum :ticket_severity, ["trivial", "minor", "major", "critical", "blocker"]
+  create_enum :product_category, ["electronics", "clothing", "books", "food", "home_garden", "sports", "toys", "health_beauty"]
+  create_enum :notification_type, ["email", "sms", "push", "in_app", "webhook"]
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "username", null: false
+    t.string "encrypted_password"
+    # Using integer for enum (Rails convention)
+    t.integer "status", default: 0, null: false
+    # Or using PostgreSQL enum type
+    # t.enum "status", enum_type: :user_status, default: "pending_verification", null: false
+    t.integer "role", default: 0, null: false
+    t.string "first_name"
+    t.string "last_name"
+    t.date "birth_date"
+    t.datetime "last_sign_in_at"
+    t.string "last_sign_in_ip"
+    t.integer "sign_in_count", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
+    t.index ["status"], name: "index_users_on_status"
+  end
+
+  create_table "profiles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "phone_number"
+    t.text "bio"
+    t.string "avatar_url"
+    t.string "location"
+    t.string "website"
+    t.jsonb "social_links", default: {}
+    t.jsonb "preferences", default: {}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id", unique: true
+  end
+
+  create_table "products", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.decimal "price", precision: 10, scale: 2, null: false
+    # Using integer for enum
+    t.integer "category", null: false
+    # Or using PostgreSQL enum
+    # t.enum "category", enum_type: :product_category, null: false
+    t.integer "stock_quantity", default: 0
+    t.string "sku", null: false
+    t.boolean "active", default: true
+    t.string "image_url"
+    t.jsonb "attributes", default: {}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category"], name: "index_products_on_category"
+    t.index ["sku"], name: "index_products_on_sku", unique: true
+    t.index ["active"], name: "index_products_on_active"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "order_number", null: false
+    # Using integer for enums
+    t.integer "status", default: 0, null: false
+    t.integer "payment_method", null: false
+    # Or using PostgreSQL enums
+    # t.enum "status", enum_type: :order_status, default: "pending", null: false
+    # t.enum "payment_method", enum_type: :payment_method, null: false
+    t.decimal "subtotal", precision: 10, scale: 2
+    t.decimal "tax_amount", precision: 10, scale: 2
+    t.decimal "shipping_amount", precision: 10, scale: 2
+    t.decimal "total_amount", precision: 10, scale: 2, null: false
+    t.text "shipping_address"
+    t.text "billing_address"
+    t.text "notes"
+    t.datetime "shipped_at"
+    t.datetime "delivered_at"
+    t.datetime "cancelled_at"
+    t.jsonb "metadata", default: {}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_orders_on_user_id"
+    t.index ["order_number"], name: "index_orders_on_order_number", unique: true
+    t.index ["status"], name: "index_orders_on_status"
+  end
+
+  create_table "order_items", force: :cascade do |t|
+    t.bigint "order_id", null: false
+    t.bigint "product_id", null: false
+    t.integer "quantity", null: false
+    t.decimal "unit_price", precision: 10, scale: 2, null: false
+    t.decimal "discount_amount", precision: 10, scale: 2, default: "0.0"
+    t.decimal "subtotal", precision: 10, scale: 2, null: false
+    t.jsonb "customizations", default: {}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_order_items_on_order_id"
+    t.index ["product_id"], name: "index_order_items_on_product_id"
+  end
+
+  create_table "support_tickets", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "ticket_number", null: false
+    t.string "title", null: false
+    t.text "description", null: false
+    # Using integer for enums
+    t.integer "priority", default: 1, null: false
+    t.integer "severity", default: 1, null: false
+    t.integer "status", default: 0, null: false
+    # Or using PostgreSQL enums
+    # t.enum "priority", enum_type: :priority_level, default: "medium", null: false
+    # t.enum "severity", enum_type: :ticket_severity, default: "minor", null: false
+    t.bigint "assigned_to_id"
+    t.datetime "resolved_at"
+    t.text "resolution_notes"
+    t.jsonb "tags", default: []
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_support_tickets_on_user_id"
+    t.index ["assigned_to_id"], name: "index_support_tickets_on_assigned_to_id"
+    t.index ["ticket_number"], name: "index_support_tickets_on_ticket_number", unique: true
+    t.index ["priority"], name: "index_support_tickets_on_priority"
+    t.index ["severity"], name: "index_support_tickets_on_severity"
+    t.index ["status"], name: "index_support_tickets_on_status"
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.string "commentable_type", null: false
+    t.bigint "commentable_id", null: false
+    t.bigint "user_id", null: false
+    t.text "content", null: false
+    t.boolean "internal", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "notification_preferences", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    # Using integer array for multiple enum values
+    t.integer "enabled_types", array: true, default: [0, 3]
+    # Or using PostgreSQL enum array
+    # t.enum "enabled_types", array: true, enum_type: :notification_type, default: ["email", "in_app"]
+    t.integer "email_frequency", default: 0
+    t.time "quiet_hours_start"
+    t.time "quiet_hours_end"
+    t.integer "quiet_days", array: true, default: []
+    t.boolean "marketing_emails", default: true
+    t.boolean "product_updates", default: true
+    t.boolean "newsletter", default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_notification_preferences_on_user_id", unique: true
+  end
+
+  create_table "payments", force: :cascade do |t|
+    t.bigint "order_id", null: false
+    t.decimal "amount", precision: 10, scale: 2, null: false
+    t.integer "payment_method", null: false
+    t.integer "status", default: 0, null: false
+    t.string "transaction_id"
+    t.string "gateway_response"
+    t.jsonb "gateway_data", default: {}
+    t.datetime "processed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_payments_on_order_id", unique: true
+    t.index ["transaction_id"], name: "index_payments_on_transaction_id", unique: true
+    t.index ["status"], name: "index_payments_on_status"
+  end
+
+  create_table "reviews", force: :cascade do |t|
+    t.bigint "product_id", null: false
+    t.bigint "user_id", null: false
+    t.integer "rating", null: false
+    t.string "title"
+    t.text "comment"
+    t.boolean "verified_purchase", default: false
+    t.integer "helpful_count", default: 0
+    t.jsonb "images", default: []
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_reviews_on_product_id"
+    t.index ["user_id"], name: "index_reviews_on_user_id"
+    t.index ["rating"], name: "index_reviews_on_rating"
+    t.index ["product_id", "user_id"], name: "index_reviews_on_product_id_and_user_id", unique: true
+  end
+
+  create_table "audit_logs", force: :cascade do |t|
+    t.string "auditable_type", null: false
+    t.bigint "auditable_id", null: false
+    t.string "action", null: false
+    t.bigint "user_id"
+    t.jsonb "changes", default: {}
+    t.inet "ip_address"
+    t.string "user_agent"
+    t.datetime "created_at", null: false
+    t.index ["auditable_type", "auditable_id"], name: "index_audit_logs_on_auditable"
+    t.index ["user_id"], name: "index_audit_logs_on_user_id"
+    t.index ["action"], name: "index_audit_logs_on_action"
+  end
+
+  # Active Storage tables (for file uploads)
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  # Foreign Key Constraints
+  add_foreign_key "profiles", "users"
+  add_foreign_key "orders", "users"
+  add_foreign_key "order_items", "orders"
+  add_foreign_key "order_items", "products"
+  add_foreign_key "support_tickets", "users"
+  add_foreign_key "support_tickets", "users", column: "assigned_to_id"
+  add_foreign_key "comments", "users"
+  add_foreign_key "notification_preferences", "users"
+  add_foreign_key "payments", "orders"
+  add_foreign_key "reviews", "products"
+  add_foreign_key "reviews", "users"
+  add_foreign_key "audit_logs", "users"
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+end

--- a/tbls/.tbls.yml
+++ b/tbls/.tbls.yml
@@ -1,0 +1,81 @@
+# tbls configuration file
+# https://github.com/k1LoW/tbls
+
+# Database connection
+dsn: postgres://user:password@localhost:5432/sample_db?sslmode=disable
+# For MySQL: mysql://user:password@localhost:3306/sample_db
+
+# Documentation settings
+docPath: docs/schema
+
+# Format for output
+format:
+  adjust: true
+  sort: true
+  
+# ER diagram settings
+er:
+  distance: 2
+  
+# Include/Exclude settings
+include:
+  - public.*
+  
+# exclude:
+#   - public.migrations
+#   - public.schema_version
+
+# Lint rules for schema
+lint:
+  enabled: true
+  rules:
+    requireTableComment:
+      enabled: true
+      exclude:
+        - public.migrations
+    requireColumnComment:
+      enabled: true
+      allOrNothing: false
+    requireIndexComment:
+      enabled: false
+    requireConstraintComment:
+      enabled: false
+    unrelatedTable:
+      enabled: true
+      allOrNothing: false
+    columnCount:
+      enabled: true
+      max: 30
+    requireColumns:
+      enabled: true
+      columns:
+        - name: created_at
+          exclude:
+            - public.migrations
+        - name: updated_at
+          exclude:
+            - public.migrations
+    labelStyleBigQuery:
+      enabled: false
+
+# Additional settings
+comments:
+  - table: users
+    comment: "System users table with authentication and profile information"
+    columns:
+      - name: status
+        comment: "User account status using enum type"
+  - table: orders
+    comment: "Customer orders with status tracking"
+    columns:
+      - name: status
+        comment: "Order fulfillment status using enum type"
+      - name: payment_method
+        comment: "Payment method selected for the order"
+  - table: support_tickets
+    comment: "Customer support ticket system"
+    columns:
+      - name: priority
+        comment: "Ticket priority level using enum type"
+      - name: severity
+        comment: "Issue severity classification"

--- a/tbls/schema.sql
+++ b/tbls/schema.sql
@@ -1,0 +1,272 @@
+-- PostgreSQL Schema for tbls Documentation with Enum Types
+-- This schema includes comprehensive comments for documentation generation
+
+-- Create custom enum types with comments
+COMMENT ON TYPE user_status IS 'Enumeration of possible user account statuses';
+CREATE TYPE user_status AS ENUM (
+    'active',
+    'inactive', 
+    'suspended',
+    'pending_verification',
+    'deleted'
+);
+
+COMMENT ON TYPE order_status IS 'Enumeration of order fulfillment statuses';
+CREATE TYPE order_status AS ENUM (
+    'pending',
+    'processing',
+    'shipped',
+    'delivered',
+    'cancelled',
+    'refunded'
+);
+
+COMMENT ON TYPE payment_method IS 'Available payment methods for orders';
+CREATE TYPE payment_method AS ENUM (
+    'credit_card',
+    'debit_card',
+    'paypal',
+    'bank_transfer',
+    'cash_on_delivery',
+    'cryptocurrency'
+);
+
+COMMENT ON TYPE priority_level IS 'Priority levels for support tickets';
+CREATE TYPE priority_level AS ENUM (
+    'low',
+    'medium',
+    'high',
+    'urgent',
+    'critical'
+);
+
+COMMENT ON TYPE ticket_severity IS 'Severity classification for support issues';
+CREATE TYPE ticket_severity AS ENUM (
+    'trivial',
+    'minor',
+    'major',
+    'critical',
+    'blocker'
+);
+
+COMMENT ON TYPE product_category IS 'Product categorization enum';
+CREATE TYPE product_category AS ENUM (
+    'electronics',
+    'clothing',
+    'books',
+    'food',
+    'home_garden',
+    'sports',
+    'toys',
+    'health_beauty'
+);
+
+COMMENT ON TYPE notification_channel IS 'Available notification delivery channels';
+CREATE TYPE notification_channel AS ENUM (
+    'email',
+    'sms',
+    'push',
+    'in_app',
+    'webhook'
+);
+
+-- Create tables with comprehensive comments
+
+-- Users table
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    username VARCHAR(100) UNIQUE NOT NULL,
+    status user_status DEFAULT 'pending_verification' NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE users IS 'System users with authentication and account status management';
+COMMENT ON COLUMN users.id IS 'Unique user identifier';
+COMMENT ON COLUMN users.email IS 'User email address for authentication';
+COMMENT ON COLUMN users.username IS 'Unique username for display purposes';
+COMMENT ON COLUMN users.status IS 'Current account status (enum: active, inactive, suspended, pending_verification, deleted)';
+COMMENT ON COLUMN users.created_at IS 'Timestamp of user registration';
+COMMENT ON COLUMN users.updated_at IS 'Last modification timestamp';
+
+-- User profiles table
+CREATE TABLE user_profiles (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+    first_name VARCHAR(100),
+    last_name VARCHAR(100),
+    phone VARCHAR(20),
+    bio TEXT,
+    avatar_url VARCHAR(500),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE user_profiles IS 'Extended user profile information';
+COMMENT ON COLUMN user_profiles.user_id IS 'Reference to users table';
+COMMENT ON COLUMN user_profiles.first_name IS 'User first name';
+COMMENT ON COLUMN user_profiles.last_name IS 'User last name';
+COMMENT ON COLUMN user_profiles.phone IS 'Contact phone number';
+COMMENT ON COLUMN user_profiles.bio IS 'User biography or description';
+COMMENT ON COLUMN user_profiles.avatar_url IS 'URL to user avatar image';
+
+-- Products table
+CREATE TABLE products (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    price DECIMAL(10, 2) NOT NULL,
+    category product_category NOT NULL,
+    stock_quantity INTEGER DEFAULT 0,
+    sku VARCHAR(100) UNIQUE,
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE products IS 'Product catalog with inventory tracking';
+COMMENT ON COLUMN products.id IS 'Unique product identifier';
+COMMENT ON COLUMN products.name IS 'Product display name';
+COMMENT ON COLUMN products.description IS 'Detailed product description';
+COMMENT ON COLUMN products.price IS 'Current product price';
+COMMENT ON COLUMN products.category IS 'Product category classification (enum)';
+COMMENT ON COLUMN products.stock_quantity IS 'Available inventory count';
+COMMENT ON COLUMN products.sku IS 'Stock keeping unit for inventory management';
+COMMENT ON COLUMN products.is_active IS 'Whether product is available for purchase';
+
+-- Orders table
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    order_number VARCHAR(50) UNIQUE NOT NULL,
+    status order_status DEFAULT 'pending' NOT NULL,
+    payment_method payment_method NOT NULL,
+    total_amount DECIMAL(10, 2) NOT NULL,
+    shipping_address TEXT,
+    notes TEXT,
+    order_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    shipped_date TIMESTAMP,
+    delivered_date TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE orders IS 'Customer orders with status and payment tracking';
+COMMENT ON COLUMN orders.id IS 'Unique order identifier';
+COMMENT ON COLUMN orders.user_id IS 'Customer who placed the order';
+COMMENT ON COLUMN orders.order_number IS 'Human-readable order reference number';
+COMMENT ON COLUMN orders.status IS 'Current order status (enum: pending, processing, shipped, delivered, cancelled, refunded)';
+COMMENT ON COLUMN orders.payment_method IS 'Payment method used (enum)';
+COMMENT ON COLUMN orders.total_amount IS 'Total order value including tax and shipping';
+COMMENT ON COLUMN orders.shipping_address IS 'Delivery address for the order';
+COMMENT ON COLUMN orders.notes IS 'Additional order notes or special instructions';
+COMMENT ON COLUMN orders.order_date IS 'When the order was placed';
+COMMENT ON COLUMN orders.shipped_date IS 'When the order was shipped';
+COMMENT ON COLUMN orders.delivered_date IS 'When the order was delivered';
+
+-- Order items table
+CREATE TABLE order_items (
+    id SERIAL PRIMARY KEY,
+    order_id INTEGER REFERENCES orders(id) ON DELETE CASCADE,
+    product_id INTEGER REFERENCES products(id),
+    quantity INTEGER NOT NULL CHECK (quantity > 0),
+    unit_price DECIMAL(10, 2) NOT NULL,
+    discount_amount DECIMAL(10, 2) DEFAULT 0,
+    subtotal DECIMAL(10, 2) NOT NULL
+);
+
+COMMENT ON TABLE order_items IS 'Individual line items within an order';
+COMMENT ON COLUMN order_items.order_id IS 'Parent order reference';
+COMMENT ON COLUMN order_items.product_id IS 'Product being ordered';
+COMMENT ON COLUMN order_items.quantity IS 'Number of units ordered';
+COMMENT ON COLUMN order_items.unit_price IS 'Price per unit at time of order';
+COMMENT ON COLUMN order_items.discount_amount IS 'Discount applied to this line item';
+COMMENT ON COLUMN order_items.subtotal IS 'Line item total (quantity * unit_price - discount)';
+
+-- Support tickets table
+CREATE TABLE support_tickets (
+    id SERIAL PRIMARY KEY,
+    ticket_number VARCHAR(50) UNIQUE NOT NULL,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    priority priority_level DEFAULT 'medium' NOT NULL,
+    severity ticket_severity DEFAULT 'minor' NOT NULL,
+    assigned_to INTEGER REFERENCES users(id),
+    status VARCHAR(50) DEFAULT 'open',
+    resolved_at TIMESTAMP,
+    resolution_notes TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE support_tickets IS 'Customer support ticket tracking system';
+COMMENT ON COLUMN support_tickets.ticket_number IS 'Human-readable ticket reference';
+COMMENT ON COLUMN support_tickets.user_id IS 'Customer who created the ticket';
+COMMENT ON COLUMN support_tickets.title IS 'Brief ticket summary';
+COMMENT ON COLUMN support_tickets.description IS 'Detailed issue description';
+COMMENT ON COLUMN support_tickets.priority IS 'Ticket priority (enum: low, medium, high, urgent, critical)';
+COMMENT ON COLUMN support_tickets.severity IS 'Issue severity (enum: trivial, minor, major, critical, blocker)';
+COMMENT ON COLUMN support_tickets.assigned_to IS 'Support agent handling the ticket';
+COMMENT ON COLUMN support_tickets.status IS 'Current ticket status';
+COMMENT ON COLUMN support_tickets.resolved_at IS 'When the ticket was resolved';
+COMMENT ON COLUMN support_tickets.resolution_notes IS 'Notes about how the issue was resolved';
+
+-- Notification preferences table
+CREATE TABLE notification_preferences (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+    channels notification_channel[] DEFAULT '{email, in_app}',
+    email_frequency VARCHAR(20) DEFAULT 'instant',
+    quiet_hours_start TIME,
+    quiet_hours_end TIME,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE notification_preferences IS 'User notification settings and preferences';
+COMMENT ON COLUMN notification_preferences.user_id IS 'User these preferences belong to';
+COMMENT ON COLUMN notification_preferences.channels IS 'Array of enabled notification channels (enum[])';
+COMMENT ON COLUMN notification_preferences.email_frequency IS 'Email batch frequency (instant, daily, weekly)';
+COMMENT ON COLUMN notification_preferences.quiet_hours_start IS 'Start of do-not-disturb period';
+COMMENT ON COLUMN notification_preferences.quiet_hours_end IS 'End of do-not-disturb period';
+
+-- Audit log table
+CREATE TABLE audit_logs (
+    id SERIAL PRIMARY KEY,
+    table_name VARCHAR(100) NOT NULL,
+    record_id INTEGER NOT NULL,
+    action VARCHAR(20) NOT NULL,
+    user_id INTEGER REFERENCES users(id),
+    changes JSONB,
+    ip_address INET,
+    user_agent TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE audit_logs IS 'System-wide audit trail for data changes';
+COMMENT ON COLUMN audit_logs.table_name IS 'Table where change occurred';
+COMMENT ON COLUMN audit_logs.record_id IS 'ID of the affected record';
+COMMENT ON COLUMN audit_logs.action IS 'Type of action (INSERT, UPDATE, DELETE)';
+COMMENT ON COLUMN audit_logs.user_id IS 'User who made the change';
+COMMENT ON COLUMN audit_logs.changes IS 'JSON object containing before/after values';
+COMMENT ON COLUMN audit_logs.ip_address IS 'IP address of the user';
+COMMENT ON COLUMN audit_logs.user_agent IS 'Browser/client information';
+
+-- Create indexes for better performance
+CREATE INDEX idx_users_status ON users(status);
+CREATE INDEX idx_orders_status ON orders(status);
+CREATE INDEX idx_orders_user_id ON orders(user_id);
+CREATE INDEX idx_orders_order_date ON orders(order_date);
+CREATE INDEX idx_tickets_priority ON support_tickets(priority);
+CREATE INDEX idx_tickets_severity ON support_tickets(severity);
+CREATE INDEX idx_tickets_assigned_to ON support_tickets(assigned_to);
+CREATE INDEX idx_products_category ON products(category);
+CREATE INDEX idx_products_is_active ON products(is_active);
+CREATE INDEX idx_audit_logs_table_record ON audit_logs(table_name, record_id);
+
+-- Add comments to indexes
+COMMENT ON INDEX idx_users_status IS 'Index for filtering users by status';
+COMMENT ON INDEX idx_orders_status IS 'Index for filtering orders by status';
+COMMENT ON INDEX idx_tickets_priority IS 'Index for filtering tickets by priority';
+COMMENT ON INDEX idx_products_category IS 'Index for filtering products by category';

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+# Test script for validating database schemas
+# Usage: ./test.sh [postgres|mysql|prisma|tbls|rails]
+
+set -e
+
+echo "Database Schema Test Runner"
+echo "============================"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    if [ $1 -eq 0 ]; then
+        echo -e "${GREEN}✓${NC} $2"
+    else
+        echo -e "${RED}✗${NC} $2"
+    fi
+}
+
+# Test PostgreSQL schema
+test_postgres() {
+    echo -e "\n${YELLOW}Testing PostgreSQL Schema...${NC}"
+    
+    if command -v psql &> /dev/null; then
+        echo "PostgreSQL client found"
+        
+        # Check if schema file exists
+        if [ -f "postgres/schema.sql" ]; then
+            print_status 0 "Schema file exists"
+            
+            # Validate SQL syntax (dry run)
+            echo "Validating SQL syntax..."
+            psql -U postgres -d postgres -f postgres/schema.sql --set ON_ERROR_STOP=1 -v ON_ERROR_STOP=1 --single-transaction --dry-run 2>/dev/null
+            print_status $? "SQL syntax validation"
+        else
+            print_status 1 "Schema file not found"
+        fi
+    else
+        echo -e "${YELLOW}PostgreSQL client not installed, skipping...${NC}"
+    fi
+}
+
+# Test MySQL schema
+test_mysql() {
+    echo -e "\n${YELLOW}Testing MySQL Schema...${NC}"
+    
+    if command -v mysql &> /dev/null; then
+        echo "MySQL client found"
+        
+        if [ -f "mysql/schema.sql" ]; then
+            print_status 0 "Schema file exists"
+            
+            # Basic syntax check
+            echo "Checking SQL file syntax..."
+            grep -q "CREATE TABLE" mysql/schema.sql
+            print_status $? "Contains CREATE TABLE statements"
+            
+            grep -q "ENUM(" mysql/schema.sql
+            print_status $? "Contains ENUM definitions"
+        else
+            print_status 1 "Schema file not found"
+        fi
+    else
+        echo -e "${YELLOW}MySQL client not installed, skipping...${NC}"
+    fi
+}
+
+# Test Prisma schema
+test_prisma() {
+    echo -e "\n${YELLOW}Testing Prisma Schema...${NC}"
+    
+    if [ -f "prisma/schema.prisma" ]; then
+        print_status 0 "Schema file exists"
+        
+        # Check for enum definitions
+        grep -q "enum " prisma/schema.prisma
+        print_status $? "Contains enum definitions"
+        
+        # Check for model definitions
+        grep -q "model " prisma/schema.prisma
+        print_status $? "Contains model definitions"
+        
+        # If Prisma is installed, validate the schema
+        if command -v npx &> /dev/null; then
+            cd prisma
+            if npx prisma validate 2>/dev/null; then
+                print_status 0 "Prisma schema validation"
+            else
+                print_status 1 "Prisma schema validation"
+            fi
+            cd ..
+        else
+            echo -e "${YELLOW}Node/NPX not installed, skipping Prisma validation...${NC}"
+        fi
+    else
+        print_status 1 "Schema file not found"
+    fi
+}
+
+# Test tbls configuration
+test_tbls() {
+    echo -e "\n${YELLOW}Testing tbls Configuration...${NC}"
+    
+    if [ -f "tbls/.tbls.yml" ]; then
+        print_status 0 "tbls config file exists"
+    else
+        print_status 1 "tbls config file not found"
+    fi
+    
+    if [ -f "tbls/schema.sql" ]; then
+        print_status 0 "Schema file exists"
+        
+        # Check for comments (important for tbls)
+        grep -q "COMMENT ON" tbls/schema.sql
+        print_status $? "Contains COMMENT statements for documentation"
+    else
+        print_status 1 "Schema file not found"
+    fi
+}
+
+# Test Rails schema
+test_rails() {
+    echo -e "\n${YELLOW}Testing Rails Schema...${NC}"
+    
+    if [ -f "schemarb/schema.rb" ]; then
+        print_status 0 "schema.rb file exists"
+        
+        # Check for Rails schema version
+        grep -q "ActiveRecord::Schema" schemarb/schema.rb
+        print_status $? "Valid Rails schema format"
+        
+        # Check for enum-related content
+        grep -q "t.integer.*default:" schemarb/schema.rb
+        print_status $? "Contains integer fields for enums"
+    else
+        print_status 1 "schema.rb file not found"
+    fi
+    
+    if [ -f "schemarb/models_example.rb" ]; then
+        print_status 0 "Model examples file exists"
+        
+        # Check for enum definitions in models
+        grep -q "enum " schemarb/models_example.rb
+        print_status $? "Contains enum definitions in models"
+    else
+        print_status 1 "Model examples file not found"
+    fi
+}
+
+# Main execution
+case "$1" in
+    postgres)
+        test_postgres
+        ;;
+    mysql)
+        test_mysql
+        ;;
+    prisma)
+        test_prisma
+        ;;
+    tbls)
+        test_tbls
+        ;;
+    rails)
+        test_rails
+        ;;
+    all|"")
+        echo "Running all tests..."
+        test_postgres
+        test_mysql
+        test_prisma
+        test_tbls
+        test_rails
+        echo -e "\n${GREEN}All tests completed!${NC}"
+        ;;
+    *)
+        echo "Usage: $0 [postgres|mysql|prisma|tbls|rails|all]"
+        echo "  postgres - Test PostgreSQL schema"
+        echo "  mysql    - Test MySQL schema"
+        echo "  prisma   - Test Prisma schema"
+        echo "  tbls     - Test tbls configuration"
+        echo "  rails    - Test Rails schema"
+        echo "  all      - Run all tests (default)"
+        exit 1
+        ;;
+esac
+
+echo -e "\n${YELLOW}Note:${NC} Some tests require the respective database clients to be installed."
+echo "For full testing, ensure you have: psql, mysql, node/npm, and tbls installed."


### PR DESCRIPTION
  Description:
  ## Summary
  - Added sample schemas for PostgreSQL, MySQL, Prisma, tbls, and Rails demonstrating enum type usage
  - Included various enum patterns: user status, order status, payment methods, priority levels, etc.
  - Provided test script and comprehensive README documentation

  ## Changes
  - `postgres/`: Native PostgreSQL enum types with arrays, functions, and triggers
  - `mysql/`: MySQL ENUM/SET types with stored procedures and validation triggers
  - `prisma/`: Complete Prisma ORM schema with enum definitions and relations
  - `tbls/`: PostgreSQL schema with documentation comments and tbls config
  - `schemarb/`: Rails schema.rb and model examples with enum helpers
  - Added test.sh for schema validation
  - Updated README with usage instructions

  ## Testing
  Run `./test.sh all` to validate all schema files